### PR TITLE
Fixed issues with ApiObjectField annotations complex generic types

### DIFF
--- a/jsondoc-core/src/main/java/org/jsondoc/core/pojo/ApiObjectFieldDoc.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/pojo/ApiObjectFieldDoc.java
@@ -56,10 +56,15 @@ public class ApiObjectFieldDoc {
 			if (field.getGenericType() instanceof ParameterizedType) {
 				ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
 				Type type = parameterizedType.getActualTypeArguments()[0];
+				Class<?> clazz;
 				if(type instanceof WildcardType) {
 					return new String[] { JSONDocUtils.WILDCARD, null, null, null };
+				} else if (type instanceof ParameterizedType) {
+					Type parameterType = ((ParameterizedType) type).getRawType();
+					clazz = (Class<?>) parameterType;
+				} else {
+					clazz = (Class<?>) type;
 				}
-				Class<?> clazz = (Class<?>) type;
 				return new String[] { JSONDocUtils.getObjectNameFromAnnotatedClass(clazz), null, null, null };
 			} else {
 				return new String[] { JSONDocUtils.UNDEFINED, null, null, null };

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocUtils.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocUtils.java
@@ -36,9 +36,9 @@ public class JSONDocUtils {
 	public static final String UNDEFINED = "undefined";
 	public static final String WILDCARD = "wildcard";
 	private static Reflections reflections = null;
-	
+
 	private static Logger log = Logger.getLogger(JSONDocUtils.class);
-	
+
 	/**
 	 * Returns the main <code>ApiDoc</code>, containing <code>ApiMethodDoc</code> and <code>ApiObjectDoc</code> objects
 	 * @return An <code>ApiDoc</code> object
@@ -46,7 +46,7 @@ public class JSONDocUtils {
 	public static JSONDoc getApiDoc(String version, String basePath, List<String> packages) {
 		Set<URL> urls = new HashSet<URL>();
 		FilterBuilder filter = new FilterBuilder();
-		
+
 		log.debug("Found " + packages.size() + " package(s) to scan...");
 		for (String pkg : packages) {
 			log.debug("Adding package to JSONDoc recursive scan: " + pkg);
@@ -58,13 +58,13 @@ public class JSONDocUtils {
 			.filterInputsBy(filter)
 			.setUrls(urls)
 			);
-		
+
 		JSONDoc apiDoc = new JSONDoc(version, basePath);
 		apiDoc.setApis(getApiDocs(reflections.getTypesAnnotatedWith(Api.class)));
 		apiDoc.setObjects(getApiObjectDocs(reflections.getTypesAnnotatedWith(ApiObject.class)));
 		return apiDoc;
 	}
-	
+
 	public static Set<ApiDoc> getApiDocs(Set<Class<?>> classes) {
 		Set<ApiDoc> apiDocs = new TreeSet<ApiDoc>();
 		for (Class<?> controller : classes) {
@@ -75,7 +75,7 @@ public class JSONDocUtils {
 		}
 		return apiDocs;
 	}
-	
+
 	public static Set<ApiObjectDoc> getApiObjectDocs(Set<Class<?>> classes) {
 		Set<ApiObjectDoc> pojoDocs = new TreeSet<ApiObjectDoc>();
 		for (Class<?> pojo : classes) {
@@ -88,59 +88,62 @@ public class JSONDocUtils {
 		}
 		return pojoDocs;
 	}
-	
+
 	private static List<ApiMethodDoc> getApiMethodDocs(Class<?> controller) {
 		List<ApiMethodDoc> apiMethodDocs = new ArrayList<ApiMethodDoc>();
 		Method[] methods = controller.getMethods();
 		for (Method method : methods) {
 			if(method.isAnnotationPresent(ApiMethod.class)) {
 				ApiMethodDoc apiMethodDoc = ApiMethodDoc.buildFromAnnotation(method.getAnnotation(ApiMethod.class));
-				
+
 				if(method.isAnnotationPresent(ApiHeaders.class)) {
 					apiMethodDoc.setHeaders(ApiHeaderDoc.buildFromAnnotation(method.getAnnotation(ApiHeaders.class)));
 				}
-				
+
 				apiMethodDoc.setPathparameters(ApiParamDoc.getApiParamDocs(method, ApiParamType.PATH));
-				
+
 				apiMethodDoc.setQueryparameters(ApiParamDoc.getApiParamDocs(method, ApiParamType.QUERY));
-				
+
 				apiMethodDoc.setBodyobject(ApiBodyObjectDoc.buildFromAnnotation(method));
-				
+
 				if(method.isAnnotationPresent(ApiResponseObject.class)) {
 					apiMethodDoc.setResponse(ApiResponseObjectDoc.buildFromAnnotation(method.getAnnotation(ApiResponseObject.class), method));
 				}
-				
+
 				if(method.isAnnotationPresent(ApiErrors.class)) {
 					apiMethodDoc.setApierrors(ApiErrorDoc.buildFromAnnotation(method.getAnnotation(ApiErrors.class)));
 				}
-				
+
 				apiMethodDocs.add(apiMethodDoc);
 			}
-			
+
 		}
 		return apiMethodDocs;
 	}
-	
+
 	public static String getObjectNameFromAnnotatedClass(Class<?> clazz) {
+		if (clazz.isArray()) {
+			clazz = clazz.getComponentType();
+		}
 		Class<?> annotatedClass = ReflectionUtils.forName(clazz.getName());
 		if(annotatedClass.isAnnotationPresent(ApiObject.class)) {
 			return annotatedClass.getAnnotation(ApiObject.class).name();
 		}
 		return clazz.getSimpleName().toLowerCase();
 	}
-	
+
 	public static boolean isMultiple(Method method) {
 		if(Collection.class.isAssignableFrom(method.getReturnType()) || method.getReturnType().isArray()) {
 			return true;
 		}
 		return false;
 	}
-	
+
 	public static boolean isMultiple(Class<?> clazz) {
 		if(Collection.class.isAssignableFrom(clazz) || clazz.isArray()) {
 			return true;
 		}
 		return false;
 	}
-	
+
 }

--- a/jsondoc-core/src/test/java/org/jsondoc/core/doc/ApiObjectDocTest.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/doc/ApiObjectDocTest.java
@@ -14,80 +14,103 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ApiObjectDocTest {
-	
+
 	@ApiObject(name="test-object")
 	private class TestObject {
-		
+
 		@ApiObjectField(description="the test name")
 		private String name;
-		
+
 		@ApiObjectField(description="the test age")
 		private Integer age;
-		
+
 		@ApiObjectField(description="the test avg")
 		private Long avg;
-		
+
 		@ApiObjectField(description="the test map")
 		private Map<String, Integer> map;
-		
+
 		@SuppressWarnings("rawtypes")
-		@ApiObjectField(description="an unparametrized list to test https://github.com/fabiomaffioletti/jsondoc/issues/5")
-		private List unparametrizedList;
-		
-		@ApiObjectField(description="a parametrized list")
-		private List<String> parametrizedList;
-		
-		@ApiObjectField(description="a wildcard parametrized list to test https://github.com/fabiomaffioletti/jsondoc/issues/5")
-		private List<?> wildcardParametrized;
-		
+		@ApiObjectField(description="an unparameterized list to test https://github.com/fabiomaffioletti/jsondoc/issues/5")
+		private List unparameterizedList;
+
+		@ApiObjectField(description="a parameterized list")
+		private List<String> parameterizedList;
+
+		@ApiObjectField(description="a wildcard parameterized list to test https://github.com/fabiomaffioletti/jsondoc/issues/5")
+		private List<?> wildcardParameterized;
+
+		@ApiObjectField(description="a parameterized list where the Type Param is generically typed")
+		private List<Set<?>> parameterizedListOfGenericType;
+
+		@ApiObjectField(description="an array parameterized list where the Type Param is an array")
+		private List<String[]> parameterizedListOfArray;
+
 	}
-	
+
 	@Test
 	public void testApiObjectDoc() {
 		Set<Class<?>> classes = new HashSet<Class<?>>();
 		classes.add(TestObject.class);
-		ApiObjectDoc childDoc = JSONDocUtils.getApiObjectDocs(classes).iterator().next(); 
+		ApiObjectDoc childDoc = JSONDocUtils.getApiObjectDocs(classes).iterator().next();
 		Assert.assertEquals("test-object", childDoc.getName());
-		Assert.assertEquals(7, childDoc.getFields().size());
-		
-		for (ApiObjectFieldDoc fieldDoc : childDoc.getFields()) {
-			if(fieldDoc.getName().equals("wildcardParametrized")) {
-				Assert.assertEquals("wildcard", fieldDoc.getType());
-				Assert.assertEquals("true", fieldDoc.getMultiple());
-			}
-			
-			if(fieldDoc.getName().equals("unparametrizedList")) {
-				Assert.assertEquals("undefined", fieldDoc.getType());
-				Assert.assertEquals("true", fieldDoc.getMultiple());
-			}
-			
-			if(fieldDoc.getName().equals("parametrizedList")) {
-				Assert.assertEquals("string", fieldDoc.getType());
-				Assert.assertEquals("true", fieldDoc.getMultiple());
-			}
-			
-			if(fieldDoc.getName().equals("name")) {
-				Assert.assertEquals("string", fieldDoc.getType());
-				Assert.assertEquals("false", fieldDoc.getMultiple());
-			}
-			
-			if(fieldDoc.getName().equals("age")) {
-				Assert.assertEquals("integer", fieldDoc.getType());
-				Assert.assertEquals("false", fieldDoc.getMultiple());
-			}
-			
-			if(fieldDoc.getName().equals("avg")) {
-				Assert.assertEquals("long", fieldDoc.getType());
-				Assert.assertEquals("false", fieldDoc.getMultiple());
-			}
-			
-			if(fieldDoc.getName().equals("map")) {
-				Assert.assertEquals("map", fieldDoc.getType());
-				Assert.assertEquals("string", fieldDoc.getMapKeyObject());
-				Assert.assertEquals("integer", fieldDoc.getMapValueObject());
-				Assert.assertEquals("false", fieldDoc.getMultiple());
+		Assert.assertEquals(9, childDoc.getFields().size());
+
+		ApiObjectFieldDoc fieldDoc = getFieldDoc(childDoc.getFields(), "parameterizedListOfArray");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("string", fieldDoc.getType());
+		Assert.assertEquals("true", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "parameterizedListOfGenericType");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("set", fieldDoc.getType());
+		Assert.assertEquals("true", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "wildcardParameterized");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("wildcard", fieldDoc.getType());
+		Assert.assertEquals("true", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "unparameterizedList");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("undefined", fieldDoc.getType());
+		Assert.assertEquals("true", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "parameterizedList");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("string", fieldDoc.getType());
+		Assert.assertEquals("true", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "name");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("string", fieldDoc.getType());
+		Assert.assertEquals("false", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "age");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("integer", fieldDoc.getType());
+		Assert.assertEquals("false", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "avg");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("long", fieldDoc.getType());
+		Assert.assertEquals("false", fieldDoc.getMultiple());
+
+		fieldDoc = getFieldDoc(childDoc.getFields(), "map");
+		Assert.assertNotNull(fieldDoc);
+		Assert.assertEquals("map", fieldDoc.getType());
+		Assert.assertEquals("string", fieldDoc.getMapKeyObject());
+		Assert.assertEquals("integer", fieldDoc.getMapValueObject());
+		Assert.assertEquals("false", fieldDoc.getMultiple());
+	}
+
+	private ApiObjectFieldDoc getFieldDoc(List<ApiObjectFieldDoc> fieldDocs, String fieldName) {
+		for (ApiObjectFieldDoc fieldDoc : fieldDocs) {
+			if (fieldDoc.getName().equals(fieldName)) {
+				return fieldDoc;
 			}
 		}
+		return null;
 	}
 
 }


### PR DESCRIPTION
Fixed issues with ApiObjectField annotations on fields with a Collection of Generically Typed elements and a Collection of Arrays.  Also updated the ApiObjectDocTests to fail fast when a field is not found in the output
