### PR TITLE
Fix for Issue #81

### DIFF
--- a/jsondoc-core/pom.xml
+++ b/jsondoc-core/pom.xml
@@ -23,10 +23,10 @@
 			<artifactId>reflections</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -39,6 +39,14 @@
 			<artifactId>jackson-mapper-asl</artifactId>
 			<scope>test</scope>
 		</dependency>
+    
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
+        
 	</dependencies>
 
 	<build>

--- a/jsondoc-core/pom.xml
+++ b/jsondoc-core/pom.xml
@@ -27,6 +27,18 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -39,14 +51,7 @@
 			<artifactId>jackson-mapper-asl</artifactId>
 			<scope>test</scope>
 		</dependency>
-    
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>test</scope>
-        </dependency>
-        
+		
 	</dependencies>
 
 	<build>

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/AbstractJSONDocScanner.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/AbstractJSONDocScanner.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.apache.log4j.Logger;
 import org.jsondoc.core.annotation.Api;
 import org.jsondoc.core.annotation.ApiAuthBasic;
 import org.jsondoc.core.annotation.ApiAuthNone;
@@ -42,12 +41,14 @@ import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractJSONDocScanner implements JSONDocScanner {
 	
 	protected Reflections reflections = null;
 	
-	protected static Logger log = Logger.getLogger(JSONDocScanner.class);
+	protected static Logger log = LoggerFactory.getLogger(JSONDocScanner.class);
 	
 	public abstract ApiDoc mergeApiDoc(Class<?> controller, ApiDoc apiDoc);
 	

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/DefaultJSONDocScannerTest.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/DefaultJSONDocScannerTest.java
@@ -1,13 +1,15 @@
 package org.jsondoc.core.util;
 
 import com.google.common.collect.Lists;
-import org.apache.log4j.Logger;
+
 import org.codehaus.jackson.map.ObjectMapper;
 import org.jsondoc.core.pojo.ApiDoc;
 import org.jsondoc.core.pojo.ApiMethodDoc;
 import org.jsondoc.core.pojo.ApiVerb;
 import org.jsondoc.core.pojo.JSONDoc;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -20,7 +22,7 @@ public class DefaultJSONDocScannerTest {
     private String basePath = "http://localhost:8080/api";
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    private static Logger log = Logger.getLogger(DefaultJSONDocScannerTest.class);
+    private static Logger log = LoggerFactory.getLogger(DefaultJSONDocScannerTest.class);
 
     @Test
     public void getJSONDoc() throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,23 @@
 
 			<!-- Logging -->
             <dependency>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-              <version>1.7.10</version>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.10</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.10</version>
+                <scope>test</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+                <scope>test</scope>
             </dependency>
 
 			<!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,11 @@
 			</dependency>
 
 			<!-- Logging -->
-			<dependency>
-				<groupId>log4j</groupId>
-				<artifactId>log4j</artifactId>
-				<version>1.2.17</version>
-			</dependency>
+            <dependency>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+              <version>1.7.10</version>
+            </dependency>
 
 			<!-- Test -->
 			<dependency>


### PR DESCRIPTION
I have added slf4j-api as the logging facade. In order to reuse your log4j configuration, slf4j-log4j12 is needed to bridge log4j's legacy api.

```
Logger log = Logger.getLogger();
```
is changed to 
```
Logger log = LoggerFactory.getLogger();
```
in all affected classes (i.e. AbstractJSONDocScanner.java and DefaultJSONDocScannerTest.java).

DefaultJSONDocScannerTest in jsondoc-core runs with logging output as expected.
