### PR TITLE
Fix NPE during startup when Sprint.getVersion() returns null

### DIFF
--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/controller/JSONDocController.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/controller/JSONDocController.java
@@ -31,7 +31,7 @@ public class JSONDocController {
 		this.basePath = basePath;
 		this.packages = packages;
 		String springVersion = SpringVersion.getVersion();
-		if(!springVersion.isEmpty()) {
+		if(springVersion != null && !springVersion.isEmpty()) {
 			Integer majorSpringVersion = Integer.parseInt(springVersion.split("\\.")[0]);
 			if(majorSpringVersion > SPRING_VERSION_3_X) {
 				this.jsondocScanner = new Spring4JSONDocScanner();


### PR DESCRIPTION
That can happen in some containers like tomcat8 and probably others.