### PR TITLE
Adding required data to generate clients from jsondoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.iml
 *.ipr
 *.iws
+*.eml

--- a/jsondoc-core/src/main/java/org/jsondoc/core/pojo/ApiMethodDoc.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/pojo/ApiMethodDoc.java
@@ -30,6 +30,7 @@ public class ApiMethodDoc extends AbstractDoc implements Comparable<ApiMethodDoc
 	private String id;
 	private String description;
 	private String summary;
+	private String methodName;
 
 	private List<ApiErrorDoc> apierrors;
 	private ApiVersionDoc supportedversions;
@@ -41,6 +42,7 @@ public class ApiMethodDoc extends AbstractDoc implements Comparable<ApiMethodDoc
 		this.id = null;
 		this.description = "";
 		this.summary = "";
+		this.methodName = "";
 		this.path = new LinkedHashSet<String>();
 		this.verb = new LinkedHashSet<ApiVerb>();
 		this.produces = new LinkedHashSet<String>();
@@ -105,6 +107,16 @@ public class ApiMethodDoc extends AbstractDoc implements Comparable<ApiMethodDoc
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public String getMethodName()
+	{
+		return methodName;
+	}
+
+	public void setMethodName(String methodName)
+	{
+		this.methodName = methodName;
 	}
 
 	public Set<ApiParamDoc> getPathparameters() {

--- a/jsondoc-core/src/main/java/org/jsondoc/core/scanner/builder/JSONDocApiMethodDocBuilder.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/scanner/builder/JSONDocApiMethodDocBuilder.java
@@ -22,6 +22,7 @@ public class JSONDocApiMethodDocBuilder {
 		apiMethodDoc.setPath(new LinkedHashSet<String>(Arrays.asList(methodAnnotation.path())));
 		apiMethodDoc.setSummary(methodAnnotation.summary());
 		apiMethodDoc.setDescription(methodAnnotation.description());
+		apiMethodDoc.setMethodName(method.getName());
 		apiMethodDoc.setVerb(new LinkedHashSet<ApiVerb>(Arrays.asList(methodAnnotation.verb())));
 		apiMethodDoc.setConsumes(new LinkedHashSet<String>(Arrays.asList(methodAnnotation.consumes())));
 		apiMethodDoc.setProduces(new LinkedHashSet<String>(Arrays.asList(methodAnnotation.produces())));

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocType.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocType.java
@@ -6,7 +6,7 @@ import java.util.List;
 public class JSONDocType {
 
 	private List<String> type = new LinkedList<String>();
-
+	private List<String> classType = new LinkedList<String>();
 	private JSONDocType mapKey;
 
 	private JSONDocType mapValue;
@@ -21,6 +21,11 @@ public class JSONDocType {
 
 	public void addItemToType(String item) {
 		this.type.add(item);
+	}
+
+	public void addItemToClassType(String classType)
+	{
+		this.classType.add(classType);
 	}
 
 	public String getOneLineText() {
@@ -47,6 +52,16 @@ public class JSONDocType {
 
 	public void setType(List<String> type) {
 		this.type = type;
+	}
+
+	public List<String> getClassType()
+	{
+		return classType;
+	}
+
+	public void setClassType(List<String> classType)
+	{
+		this.classType = classType;
 	}
 
 	public JSONDocType getMapKey() {

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocTypeBuilder.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocTypeBuilder.java
@@ -1,5 +1,7 @@
 package org.jsondoc.core.util;
 
+import org.jsondoc.core.annotation.ApiObject;
+
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -8,8 +10,6 @@ import java.lang.reflect.WildcardType;
 import java.util.Collection;
 import java.util.Map;
 
-import org.jsondoc.core.annotation.ApiObject;
-
 public class JSONDocTypeBuilder {
 	
 	private static final String WILDCARD = "wildcard";
@@ -17,6 +17,9 @@ public class JSONDocTypeBuilder {
 	private static final String ARRAY = "array";
 
 	public static JSONDocType build(JSONDocType jsondocType, Class<?> clazz, Type type) {
+
+		jsondocType.addItemToClassType(getTypeString(type));
+
 		if(clazz.isAssignableFrom(JSONDocDefaultType.class)) {
 			jsondocType.addItemToType(UNDEFINED);
 			return jsondocType;
@@ -58,7 +61,7 @@ public class JSONDocTypeBuilder {
 			if (type instanceof ParameterizedType) {
 				Type parametrizedType = ((ParameterizedType) type).getActualTypeArguments()[0];
 				jsondocType.addItemToType(getCustomClassName(clazz));
-				
+
 				if (parametrizedType instanceof Class) {
 					jsondocType.addItemToType(getCustomClassName((Class<?>) parametrizedType));
 				} else if (parametrizedType instanceof WildcardType) {
@@ -110,6 +113,27 @@ public class JSONDocTypeBuilder {
 		} else {
 			return clazz.getSimpleName().toLowerCase();
 		}
+	}
+
+	private static String getTypeString(Type type)
+	{
+		if(type == null)
+			return UNDEFINED;
+
+		String typeName = null;
+		if(type instanceof ParameterizedType)
+		{
+			ParameterizedType ptype = (ParameterizedType) type;
+			if(ptype.getOwnerType() != null)
+				typeName = ptype.getRawType().getTypeName();
+		}
+
+		if(typeName == null)
+			typeName = type.getTypeName();
+
+		//For nested classes, remove the $ and add a dot notation so its a valid
+		//java reference.
+		return typeName.replace("$",".");
 	}
 
 }

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTypeBuilderTest.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTypeBuilderTest.java
@@ -145,7 +145,7 @@ public class JSONDocTypeBuilderTest {
 	public List<ParentPojo> getParentPojoList() {
 		return null;
 	}
-	
+
 	public <T> FooPojo<T> getSpecializedWGenericsPojo() {
 		return null;
 	}
@@ -172,6 +172,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("string", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.lang.String", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -180,6 +181,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("integer", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.lang.Integer", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -188,6 +190,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("int", jsonDocType.getOneLineText());
+		Assert.assertEquals("int", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -196,6 +199,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("long", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.lang.Long", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -204,6 +208,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("long", jsonDocType.getOneLineText());
+		Assert.assertEquals("long", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -212,6 +217,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("list of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List<java.lang.String>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -220,6 +226,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("list of set of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List<java.util.Set<java.lang.String>>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -228,6 +235,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.lang.String[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -236,6 +244,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of integer", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.lang.Integer[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -244,6 +253,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of list of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List<java.lang.String>[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -252,6 +262,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of set of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Set<java.lang.String>[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -260,6 +271,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("list", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -268,6 +280,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("list of wildcard", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List<?>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -276,6 +289,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of list of wildcard", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List<?>[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -284,6 +298,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of list", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -292,6 +307,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("array of set", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Set[]", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -300,6 +316,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -308,6 +325,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("hashmap", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.HashMap", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -316,6 +334,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[string, integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.lang.String, java.lang.Integer>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -324,6 +343,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[list of string, integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.util.List<java.lang.String>, java.lang.Integer>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -332,6 +352,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[string, set of integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.lang.String, java.util.Set<java.lang.Integer>>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -340,6 +361,8 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[list of string, set of integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.util.List<java.lang.String>, java.util.Set<java.lang.Integer>>",
+				jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -348,6 +371,8 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[list of set of string, set of integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.util.List<java.util.Set<java.lang.String>>, java.util.Set<java.lang.Integer>>",
+				jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -356,6 +381,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[wildcard, integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<?, java.lang.Integer>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -364,6 +390,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[wildcard, wildcard]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<?, ?>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -372,6 +399,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[list of wildcard, wildcard]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.util.List<?>, ?>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -380,6 +408,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[map, integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.util.Map, java.lang.Integer>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -388,6 +417,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("map[map[string, long], integer]", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.Map<java.util.Map<java.lang.String, java.lang.Long>, java.lang.Integer>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -396,6 +426,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("responseentity of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("org.springframework.http.ResponseEntity<java.lang.String>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 
 		jsonDocType = new JSONDocType();
@@ -404,6 +435,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("responseentity of list of string", jsonDocType.getOneLineText());
+		Assert.assertEquals("org.springframework.http.ResponseEntity<java.util.List<java.lang.String>>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -412,6 +444,7 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("list of my_parent", jsonDocType.getOneLineText());
+		Assert.assertEquals("java.util.List<org.jsondoc.core.util.JSONDocTypeBuilderTest.ParentPojo>", jsonDocType.getClassType().get(0));
 		System.out.println("---------------------------");
 		
 		jsonDocType = new JSONDocType();
@@ -420,7 +453,8 @@ public class JSONDocTypeBuilderTest {
 		System.out.println(mapper.writeValueAsString(jsonDocType));
 		System.out.println(jsonDocType.getOneLineText());
 		Assert.assertEquals("fooPojo of T", jsonDocType.getOneLineText());
-		System.out.println("---------------------------");		
+		Assert.assertEquals("org.jsondoc.core.util.JSONDocTypeBuilderTest.FooPojo", jsonDocType.getClassType().get(0));
+		System.out.println("---------------------------");
 	}
 
 }

--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
@@ -202,6 +202,7 @@ public abstract class AbstractSpringJSONDocScanner extends AbstractJSONDocScanne
 	@Override
 	public ApiMethodDoc initApiMethodDoc(Method method, Map<Class<?>, JSONDocTemplate> jsondocTemplates) {
 		ApiMethodDoc apiMethodDoc = new ApiMethodDoc();
+		apiMethodDoc.setMethodName(method.getName());
 		apiMethodDoc.setPath(SpringPathBuilder.buildPath(method));
 		apiMethodDoc.setVerb(SpringVerbBuilder.buildVerb(method));
 		apiMethodDoc.setProduces(SpringProducesBuilder.buildProduces(method));

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/JSONDocSpringJSONDocScannerTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/JSONDocSpringJSONDocScannerTest.java
@@ -75,7 +75,7 @@ public class JSONDocSpringJSONDocScannerTest {
 				Assert.assertNotNull(apiMethodDoc.getAuth());
 				Assert.assertNotNull(apiMethodDoc.getSupportedversions());
 				Assert.assertFalse(apiMethodDoc.getApierrors().isEmpty());
-				
+				Assert.assertEquals("string",apiMethodDoc.getMethodName());
 				Assert.assertEquals("string", apiMethodDoc.getBodyobject().getJsondocType().getOneLineText());
 				Assert.assertEquals("string", apiMethodDoc.getResponse().getJsondocType().getOneLineText());
 				Assert.assertEquals("/api/string/{name}", apiMethodDoc.getPath().iterator().next());

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/PlainSpringJSONDocScannerTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/PlainSpringJSONDocScannerTest.java
@@ -57,6 +57,7 @@ public class PlainSpringJSONDocScannerTest {
 			Assert.assertNull(apiMethodDoc.getSupportedversions());
 			Assert.assertTrue(apiMethodDoc.getApierrors().isEmpty());
 			Assert.assertNull(apiMethodDoc.getId());
+			Assert.assertEquals("string",apiMethodDoc.getMethodName());
 			Assert.assertEquals("", apiMethodDoc.getSummary());
 			Assert.assertEquals("", apiMethodDoc.getDescription());
 			

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/SpringApiHeadersDocTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/SpringApiHeadersDocTest.java
@@ -49,12 +49,15 @@ public class SpringApiHeadersDocTest {
 		for (ApiMethodDoc apiMethodDoc : apiDoc.getMethods()) {
 			if (apiMethodDoc.getPath().contains("/spring-api-headers-controller-method-one")) {
 				Assert.assertEquals(2, apiMethodDoc.getHeaders().size());
+				Assert.assertEquals("apiHeadersMethodOne", apiMethodDoc.getMethodName());
 			}
 			if (apiMethodDoc.getPath().contains("/spring-api-headers-controller-method-two")) {
 				Assert.assertEquals(3, apiMethodDoc.getHeaders().size());
+				Assert.assertEquals("apiHeadersMethodTwo", apiMethodDoc.getMethodName());
 			}
 			if (apiMethodDoc.getPath().contains("/spring-api-headers-controller-method-three")) {
 				Assert.assertEquals(4, apiMethodDoc.getHeaders().size());
+				Assert.assertEquals("apiHeadersMethodThree", apiMethodDoc.getMethodName());
 				Iterator<ApiHeaderDoc> headers = apiMethodDoc.getHeaders().iterator();
 				ApiHeaderDoc h1 = headers.next();
 				ApiHeaderDoc h2 = headers.next();


### PR DESCRIPTION
fixes #160 

Adding classType to JSONDocType and adding methodNames to ApiMethodDoc. This should be enough to generate java clients from json output. Refer to issue #160 for more details.

I added checks to existing unit-tests. Seemed the most appropriate. The existing tests really came in handy. Thanks for writing those!