### PR TITLE
Add support for @ApiObjectField annotations on getters and setters

### DIFF
--- a/jsondoc-core/src/main/java/org/jsondoc/core/annotation/ApiObjectField.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/annotation/ApiObjectField.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  *
  */
 @Documented
-@Target(value = ElementType.FIELD)
+@Target(value = { ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiObjectField {
 

--- a/jsondoc-core/src/main/java/org/jsondoc/core/scanner/builder/JSONDocApiObjectDocBuilder.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/scanner/builder/JSONDocApiObjectDocBuilder.java
@@ -1,6 +1,7 @@
 package org.jsondoc.core.scanner.builder;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -9,6 +10,7 @@ import org.jsondoc.core.annotation.ApiObjectField;
 import org.jsondoc.core.pojo.ApiObjectDoc;
 import org.jsondoc.core.pojo.ApiObjectFieldDoc;
 import org.jsondoc.core.scanner.DefaultJSONDocScanner;
+import org.jsondoc.core.util.JSONDocUtils;
 
 public class JSONDocApiObjectDocBuilder {
 	
@@ -17,14 +19,23 @@ public class JSONDocApiObjectDocBuilder {
 		ApiObjectDoc apiObjectDoc = new ApiObjectDoc();
 
 		Set<ApiObjectFieldDoc> fieldDocs = new TreeSet<ApiObjectFieldDoc>();
-		for (Field field : clazz.getDeclaredFields()) {
-			if (field.getAnnotation(ApiObjectField.class) != null) {
-				ApiObjectFieldDoc fieldDoc = JSONDocApiObjectFieldDocBuilder.build(field.getAnnotation(ApiObjectField.class), field);
-				fieldDoc.setSupportedversions(JSONDocApiVersionDocBuilder.build(field));
-				fieldDocs.add(fieldDoc);
-			}
-		}
 
+    for (Field field : clazz.getDeclaredFields()) {
+      if (field.getAnnotation(ApiObjectField.class) != null) {
+        ApiObjectFieldDoc fieldDoc = JSONDocApiObjectFieldDocBuilder.build(field.getAnnotation(ApiObjectField.class), field);
+        fieldDoc.setSupportedversions(JSONDocApiVersionDocBuilder.build(field));
+        fieldDocs.add(fieldDoc);
+      }
+    }
+
+    for (Method method : clazz.getDeclaredMethods()) {
+      if (JSONDocUtils.isFieldMethod(method)) {
+        ApiObjectFieldDoc fieldDoc = JSONDocApiObjectFieldDocBuilder.build(method.getAnnotation(ApiObjectField.class), method);
+        fieldDoc.setSupportedversions(JSONDocApiVersionDocBuilder.build(method));
+        fieldDocs.add(fieldDoc);
+      }
+    }
+		
 		Class<?> c = clazz.getSuperclass();
 		if (c != null) {
 			if (c.isAnnotationPresent(ApiObject.class)) {

--- a/jsondoc-core/src/main/java/org/jsondoc/core/scanner/builder/JSONDocApiObjectFieldDocBuilder.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/scanner/builder/JSONDocApiObjectFieldDocBuilder.java
@@ -1,6 +1,8 @@
 package org.jsondoc.core.scanner.builder;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 import org.jsondoc.core.annotation.ApiObjectField;
 import org.jsondoc.core.pojo.ApiObjectFieldDoc;
@@ -8,21 +10,34 @@ import org.jsondoc.core.scanner.DefaultJSONDocScanner;
 import org.jsondoc.core.util.JSONDocHibernateValidatorProcessor;
 import org.jsondoc.core.util.JSONDocType;
 import org.jsondoc.core.util.JSONDocTypeBuilder;
+import org.jsondoc.core.util.JSONDocUtils;
 
 public class JSONDocApiObjectFieldDocBuilder {
 
-	public static ApiObjectFieldDoc build(ApiObjectField annotation, Field field) {
+  public static ApiObjectFieldDoc build(ApiObjectField annotation, Field field) {
+    ApiObjectFieldDoc doc = build(annotation, field.getName(), field.getType(), field.getGenericType());
+    JSONDocHibernateValidatorProcessor.processHibernateValidatorAnnotations(field, doc);
+    return doc;
+  }
+  
+  public static ApiObjectFieldDoc build(ApiObjectField annotation, Method method) {
+    ApiObjectFieldDoc doc = build(annotation, JSONDocUtils.getPropertyName(method), method.getReturnType(), method.getGenericReturnType());
+    JSONDocHibernateValidatorProcessor.processHibernateValidatorAnnotations(method, doc);
+    return doc;
+  }
+
+  private static ApiObjectFieldDoc build(ApiObjectField annotation, String name, Class<?> type, Type genericType) {
 		ApiObjectFieldDoc apiPojoFieldDoc = new ApiObjectFieldDoc();
 		if (!annotation.name().trim().isEmpty()) {
 			apiPojoFieldDoc.setName(annotation.name());
 		} else {
-			apiPojoFieldDoc.setName(field.getName());
+			apiPojoFieldDoc.setName(name);
 		}
 		apiPojoFieldDoc.setDescription(annotation.description());
-		apiPojoFieldDoc.setJsondocType(JSONDocTypeBuilder.build(new JSONDocType(), field.getType(), field.getGenericType()));
+		apiPojoFieldDoc.setJsondocType(JSONDocTypeBuilder.build(new JSONDocType(), type, genericType));
 		// if allowedvalues property is populated on an enum field, then the enum values are overridden with the allowedvalues ones
-		if (field.getType().isEnum() && annotation.allowedvalues().length == 0) {
-			apiPojoFieldDoc.setAllowedvalues(DefaultJSONDocScanner.enumConstantsToStringArray(field.getType().getEnumConstants()));
+		if (type.isEnum() && annotation.allowedvalues().length == 0) {
+			apiPojoFieldDoc.setAllowedvalues(DefaultJSONDocScanner.enumConstantsToStringArray(type.getEnumConstants()));
 		} else {
 			apiPojoFieldDoc.setAllowedvalues(annotation.allowedvalues());
 		}
@@ -32,8 +47,6 @@ public class JSONDocApiObjectFieldDocBuilder {
 		if(!annotation.format().isEmpty()) {
 			apiPojoFieldDoc.addFormat(annotation.format());
 		}
-		
-		JSONDocHibernateValidatorProcessor.processHibernateValidatorAnnotations(field, apiPojoFieldDoc);
 		
 		return apiPojoFieldDoc;
 	}

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocFieldWrapper.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocFieldWrapper.java
@@ -1,23 +1,62 @@
 package org.jsondoc.core.util;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+import org.jsondoc.core.annotation.ApiObjectField;
 
 public class JSONDocFieldWrapper implements Comparable<JSONDocFieldWrapper> {
-	private Field field;
-	private Integer order;
+	private String name;
+	private Class<?> type;
+	private Type genericType;
+	private ApiObjectField apiObjectFieldAnnotation;
+	
+  private Integer order;
 
-	public JSONDocFieldWrapper(Field field, Integer order) {
-		this.field = field;
+	public JSONDocFieldWrapper(
+	    String name, 
+	    Class<?> type, 
+	    Type genericType,
+	    ApiObjectField apiObjectFieldAnnotation, 
+	    Integer order) {
+		
+	  this.name = name;
+		this.type = type;
+		this.genericType = genericType;
+		this.apiObjectFieldAnnotation = apiObjectFieldAnnotation;
 		this.order = order;
 	}
 
-	public Field getField() {
-		return field;
-	}
+  public String getName() {
+    return name;
+  }
 
-	public void setField(Field field) {
-		this.field = field;
-	}
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Class<?> getType() {
+    return type;
+  }
+
+  public void setType(Class<?> type) {
+    this.type = type;
+  }
+
+  public Type getGenericType() {
+    return genericType;
+  }
+
+  public void setGenericType(Type genericType) {
+    this.genericType = genericType;
+  }
+
+  public ApiObjectField getApiObjectFieldAnnotation() {
+    return apiObjectFieldAnnotation;
+  }
+
+  public void setApiObjectFieldAnnotation(ApiObjectField apiObjectFieldAnnotation) {
+    this.apiObjectFieldAnnotation = apiObjectFieldAnnotation;
+  }
 
 	public Integer getOrder() {
 		return order;
@@ -33,7 +72,7 @@ public class JSONDocFieldWrapper implements Comparable<JSONDocFieldWrapper> {
 	@Override
 	public int compareTo(JSONDocFieldWrapper o) {
 		if(this.getOrder().equals(o.getOrder())) {
-			return this.getField().getName().compareTo(o.getField().getName());
+			return this.getName().compareTo(o.getName());
 		} else {
 			return this.getOrder() - o.getOrder();
 		}

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocHibernateValidatorProcessor.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocHibernateValidatorProcessor.java
@@ -1,6 +1,6 @@
 package org.jsondoc.core.util;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.AnnotatedElement;
 
 import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.AssertTrue;
@@ -49,7 +49,7 @@ public class JSONDocHibernateValidatorProcessor {
 	private final static String CreditCardNumber_message = "must be a valid credit card number";
 	private final static String ScriptAssert_message = "script expression %s didn't evaluate to true";
 
-	public static void processHibernateValidatorAnnotations(Field field, ApiObjectFieldDoc apiPojoFieldDoc) {
+	public static void processHibernateValidatorAnnotations(AnnotatedElement field, ApiObjectFieldDoc apiPojoFieldDoc) {
 		try {
 			Class.forName("org.hibernate.validator.constraints.NotBlank");
 

--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocUtils.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocUtils.java
@@ -3,6 +3,8 @@ package org.jsondoc.core.util;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
+import org.jsondoc.core.annotation.ApiObjectField;
+
 public class JSONDocUtils {
 	
 	public static Integer getIndexOfParameterWithAnnotation(Method method, Class<?> a) {
@@ -16,5 +18,17 @@ public class JSONDocUtils {
 		}
 		return -1;
 	}
+	
+  public static boolean isFieldMethod(Method method) {
+    return (method.getAnnotation(ApiObjectField.class) != null);
+  }
 
+  public static String getPropertyName(Method method) {
+    String name = method.getName();
+    if ((name.startsWith("get") ||  name.startsWith("set")) && name.length() > 3) {
+      return name.substring(3, 4).toLowerCase() + name.substring(4);
+    } else {
+      return name;
+    }
+  }
 }

--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
@@ -155,6 +155,11 @@ public abstract class AbstractSpringJSONDocScanner extends AbstractJSONDocScanne
 			for (Field field : clazz.getDeclaredFields()) {
 				subCandidates.addAll(buildJSONDocObjectsCandidates(subCandidates, field.getType(), field.getGenericType()));
 			}
+      for (Method method : clazz.getDeclaredMethods()) {
+        if (JSONDocUtils.isFieldMethod(method)) {
+          subCandidates.addAll(buildJSONDocObjectsCandidates(subCandidates, method.getReturnType(), method.getGenericReturnType()));
+        }
+      }
 		}
 		candidates.addAll(subCandidates);
 		

--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
@@ -239,6 +239,9 @@ public abstract class AbstractSpringJSONDocScanner extends AbstractJSONDocScanne
 	public ApiObjectDoc mergeApiObjectDoc(Class<?> clazz, ApiObjectDoc apiObjectDoc) {
 		if(clazz.isAnnotationPresent(ApiObject.class)) {
 			ApiObjectDoc jsondocApiObjectDoc = JSONDocApiObjectDocBuilder.build(clazz);
+	    if (jsondocApiObjectDoc.getFields() != null) {
+	      jsondocApiObjectDoc.getFields().addAll(apiObjectDoc.getFields());
+	    }
 			BeanUtils.copyProperties(jsondocApiObjectDoc, apiObjectDoc);
 		}
 		return apiObjectDoc;

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/spring4mvc/scanner/field/MixedFieldWithAndWIthoutAnnotationTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/spring4mvc/scanner/field/MixedFieldWithAndWIthoutAnnotationTest.java
@@ -1,0 +1,61 @@
+package org.jsondoc.spring4mvc.scanner.field;
+
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.jsondoc.core.annotation.ApiObject;
+import org.jsondoc.core.annotation.ApiObjectField;
+import org.jsondoc.core.pojo.ApiObjectDoc;
+import org.jsondoc.core.pojo.ApiObjectFieldDoc;
+import org.jsondoc.core.pojo.JSONDoc;
+import org.jsondoc.core.pojo.JSONDoc.MethodDisplay;
+import org.jsondoc.springmvc.scanner.Spring4JSONDocScanner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.common.collect.Lists;
+
+public class MixedFieldWithAndWIthoutAnnotationTest {
+
+  @Test
+  public void testSpring4JSONDocScanner() {
+    Spring4JSONDocScanner jsondocScanner = new Spring4JSONDocScanner();
+    JSONDoc jsonDoc = jsondocScanner.getJSONDoc("1.0", "/field", Lists.newArrayList("org.jsondoc.spring4mvc.scanner.field"), true, MethodDisplay.URI);
+    Assert.assertEquals(1, jsonDoc.getObjects().size());
+    Set<ApiObjectDoc> objects = jsonDoc.getObjects().get("");
+    ApiObjectDoc o = objects.iterator().next();
+    ApiObjectFieldDoc[] fields = o.getFields().toArray(new ApiObjectFieldDoc[]{});
+    Arrays.sort(fields);
+    Assert.assertEquals(2, fields.length);
+    Assert.assertEquals("age", fields[0].getName());
+    Assert.assertEquals("id", fields[1].getName());
+  }
+
+  @RestController
+  @RequestMapping(value="/spring4")
+  public class Spring4RestController {
+    @RequestMapping(value="/id-field/{customer-id}", method=GET)
+    public Spring4ObjectField getCustomer2(@PathVariable("customer-id") Long customerId) {
+      return new Spring4ObjectField();
+    }
+  }
+  
+  @ApiObject(name="Spring4ObjectField", show=true)
+  public static class Spring4ObjectField {
+    
+    @ApiObjectField(description="Hello Dolly")
+    private String id;
+    
+    // Without @ApiObjectField annotation
+    private Long age;
+    
+  }
+}
+
+  

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/spring4mvc/scanner/method/ApiObjectFieldAnnotationOnMethodTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/spring4mvc/scanner/method/ApiObjectFieldAnnotationOnMethodTest.java
@@ -1,0 +1,89 @@
+package org.jsondoc.spring4mvc.scanner.method;
+
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import java.util.Set;
+
+import org.jsondoc.core.annotation.ApiObject;
+import org.jsondoc.core.annotation.ApiObjectField;
+import org.jsondoc.core.pojo.ApiObjectDoc;
+import org.jsondoc.core.pojo.ApiObjectFieldDoc;
+import org.jsondoc.core.pojo.JSONDoc;
+import org.jsondoc.core.pojo.JSONDoc.MethodDisplay;
+import org.jsondoc.springmvc.scanner.Spring4JSONDocScanner;
+import org.junit.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.common.collect.Lists;
+
+public class ApiObjectFieldAnnotationOnMethodTest {
+
+  @Test
+  public void testSpring4JSONDocScanner() {
+    Spring4JSONDocScanner jsondocScanner = new Spring4JSONDocScanner();
+    JSONDoc jsonDoc = jsondocScanner.getJSONDoc("1.0", "/field", Lists.newArrayList("org.jsondoc.spring4mvc.scanner"), true, MethodDisplay.URI);
+    for (Set<ApiObjectDoc> o : jsonDoc.getObjects().values()) {
+      for (ApiObjectDoc api : o) {
+        System.out.println(api.getName());
+        for (ApiObjectFieldDoc field : api.getFields()) {
+          System.out.println("  " + field.getName());
+        }
+      }
+    }
+  }
+
+  @RestController
+  @RequestMapping(value="/spring4")
+  public class Spring4RestController {
+  
+    @RequestMapping(value="/method", method=GET)
+    public Spring4ObjectMethod getMethod() {
+      return new Spring4ObjectMethod() {
+        @Override
+        public String getName() { return null; }
+        @Override
+        public Long getLocation() { return null; }
+        @Override
+        public Long getA() { return null; }
+        @Override
+        public Long b() { return null; }
+        @Override
+        public Boolean setRetired() { return null; }
+      };
+    }
+  }
+  
+  @ApiObject(name="Spring4ObjectMethod", show=true)
+  public static abstract class Spring4ObjectMethod {
+    
+    private String adress;
+    
+    @ApiObjectField
+    public abstract String getName();
+    
+    @ApiObjectField
+    public abstract Boolean setRetired();
+
+    // Missing @ApiObjectField
+    public abstract Long getLocation();
+    
+    @ApiObjectField
+    public abstract Long getA();
+
+    @ApiObjectField
+    public abstract Long b();
+
+    public String getAdress() {
+      return adress;
+    }
+
+    public void setAdress(String adress) {
+      this.adress = adress;
+    }
+
+  }
+}
+
+  

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/spring4mvc/scanner/method/ApiObjectFieldAnnotationOnMethodTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/spring4mvc/scanner/method/ApiObjectFieldAnnotationOnMethodTest.java
@@ -3,6 +3,7 @@ package org.jsondoc.spring4mvc.scanner.method;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import org.jsondoc.core.annotation.ApiObject;
@@ -12,6 +13,7 @@ import org.jsondoc.core.pojo.ApiObjectFieldDoc;
 import org.jsondoc.core.pojo.JSONDoc;
 import org.jsondoc.core.pojo.JSONDoc.MethodDisplay;
 import org.jsondoc.springmvc.scanner.Spring4JSONDocScanner;
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,15 +25,19 @@ public class ApiObjectFieldAnnotationOnMethodTest {
   @Test
   public void testSpring4JSONDocScanner() {
     Spring4JSONDocScanner jsondocScanner = new Spring4JSONDocScanner();
-    JSONDoc jsonDoc = jsondocScanner.getJSONDoc("1.0", "/field", Lists.newArrayList("org.jsondoc.spring4mvc.scanner"), true, MethodDisplay.URI);
-    for (Set<ApiObjectDoc> o : jsonDoc.getObjects().values()) {
-      for (ApiObjectDoc api : o) {
-        System.out.println(api.getName());
-        for (ApiObjectFieldDoc field : api.getFields()) {
-          System.out.println("  " + field.getName());
-        }
-      }
-    }
+    JSONDoc jsonDoc = jsondocScanner.getJSONDoc("1.0", "/field", Lists.newArrayList("org.jsondoc.spring4mvc.scanner.method"), true, MethodDisplay.URI);
+    Assert.assertEquals(1, jsonDoc.getObjects().size());
+    Set<ApiObjectDoc> objects = jsonDoc.getObjects().get("");
+    ApiObjectDoc o = objects.iterator().next();
+    ApiObjectFieldDoc[] fields = o.getFields().toArray(new ApiObjectFieldDoc[]{});
+    Arrays.sort(fields);
+    Assert.assertEquals(6, fields.length);
+    Assert.assertEquals("a", fields[0].getName());
+    Assert.assertEquals("address", fields[1].getName());
+    Assert.assertEquals("b", fields[2].getName());
+    Assert.assertEquals("get", fields[3].getName());
+    Assert.assertEquals("name", fields[4].getName());
+    Assert.assertEquals("retired", fields[5].getName());
   }
 
   @RestController
@@ -51,6 +57,8 @@ public class ApiObjectFieldAnnotationOnMethodTest {
         public Long b() { return null; }
         @Override
         public Boolean setRetired() { return null; }
+        @Override
+        public Boolean get() { return null; }
       };
     }
   }
@@ -58,13 +66,16 @@ public class ApiObjectFieldAnnotationOnMethodTest {
   @ApiObject(name="Spring4ObjectMethod", show=true)
   public static abstract class Spring4ObjectMethod {
     
-    private String adress;
+    private String address;
     
     @ApiObjectField
     public abstract String getName();
     
     @ApiObjectField
     public abstract Boolean setRetired();
+
+    @ApiObjectField
+    public abstract Boolean get();
 
     // Missing @ApiObjectField
     public abstract Long getLocation();
@@ -75,14 +86,13 @@ public class ApiObjectFieldAnnotationOnMethodTest {
     @ApiObjectField
     public abstract Long b();
 
-    public String getAdress() {
-      return adress;
+    public String getAddress() {
+      return address;
     }
 
-    public void setAdress(String adress) {
-      this.adress = adress;
+    public void setAddress(String address) {
+      this.address = address;
     }
-
   }
 }
 

--- a/spring-boot-starter-jsondoc/.gitignore
+++ b/spring-boot-starter-jsondoc/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/.apt_generated/


### PR DESCRIPTION
To keep backwards compatibility, methods must be annotated with @ApiObjectField to be interpreted as field definitions.

References issues #163 and #164.

