### PR TITLE
Added null check on apiObjectField, so that only the ApiObjectField annotated fields are used

### DIFF
--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocTemplateBuilder.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocTemplateBuilder.java
@@ -44,20 +44,23 @@ public class JSONDocTemplateBuilder {
 					Field field = jsondocFieldWrapper.getField();
 					String fieldName = field.getName();
 					ApiObjectField apiObjectField = field.getAnnotation(ApiObjectField.class);
-					if (apiObjectField != null && !apiObjectField.name().isEmpty()) {
-						fieldName = apiObjectField.name();
+
+					if (apiObjectField != null) {
+					    if(!apiObjectField.name().isEmpty()) {
+					        fieldName = apiObjectField.name();
+					    }
+
+					    Object value;
+					    // This condition is to avoid StackOverflow in case class "A"
+					    // contains a field of type "A"
+					    if (field.getType().equals(clazz) || (apiObjectField != null && !apiObjectField.processtemplate())) {
+					        value = getValue(Object.class, field.getGenericType(), fieldName, jsondocObjects);
+					    } else {
+					        value = getValue(field.getType(), field.getGenericType(), fieldName, jsondocObjects);
+					    }
+
+					    jsonDocTemplate.put(fieldName, value);
 					}
-	
-					Object value;
-					// This condition is to avoid StackOverflow in case class "A"
-					// contains a field of type "A"
-					if (field.getType().equals(clazz) || (apiObjectField != null && !apiObjectField.processtemplate())) {
-						value = getValue(Object.class, field.getGenericType(), fieldName, jsondocObjects);
-					} else {
-						value = getValue(field.getType(), field.getGenericType(), fieldName, jsondocObjects);
-					}
-	
-					jsonDocTemplate.put(fieldName, value);
 				}
 	
 			} catch (Exception e) {

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTemplateBuilderTest.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTemplateBuilderTest.java
@@ -6,11 +6,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.jsondoc.core.annotation.ApiObjectField;
 import org.jsondoc.core.pojo.JSONDocTemplate;
 import org.jsondoc.core.util.pojo.TemplateObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 
@@ -51,4 +54,21 @@ public class JSONDocTemplateBuilderTest {
 		System.out.println(mapper.writeValueAsString(template));
 	}
 
+	class TestTemplateObject {
+	    @ApiObjectField
+	    private String test1;
+	    private String test2;
+	}
+	
+	@Test
+	public void testTemplateWithOnlyApiObjectFieldAnnotatedFields() throws JsonGenerationException, JsonMappingException, IOException {
+	    ObjectMapper mapper = new ObjectMapper();
+        Set<Class<?>> classes = Sets.<Class<?>>newHashSet(TestTemplateObject.class);
+        
+        Map<String, Object> template = JSONDocTemplateBuilder.build(TestTemplateObject.class, classes);
+        Assert.assertEquals("", template.get("test1"));
+        Assert.assertNull(template.get("test2"));
+        
+        System.out.println(mapper.writeValueAsString(template));
+	}
 }


### PR DESCRIPTION
Added null check on apiObjectField, so that only the ApiObjectField annotated fields are used. This is a fix for the issue https://github.com/fabiomaffioletti/jsondoc/issues/153
