### PR TITLE
Resolves #215 Class constants shouldn't be display in playground

### DIFF
--- a/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocTemplateBuilder.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/util/JSONDocTemplateBuilder.java
@@ -1,5 +1,10 @@
 package org.jsondoc.core.util;
 
+import org.jsondoc.core.annotation.ApiObjectField;
+import org.jsondoc.core.pojo.JSONDocTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -11,10 +16,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.jsondoc.core.annotation.ApiObjectField;
-import org.jsondoc.core.pojo.JSONDocTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.lang.reflect.Modifier.isFinal;
+import static java.lang.reflect.Modifier.isStatic;
 
 public class JSONDocTemplateBuilder {
 
@@ -42,6 +45,9 @@ public class JSONDocTemplateBuilder {
 	
 				for (JSONDocFieldWrapper jsondocFieldWrapper : fields) {
 					Field field = jsondocFieldWrapper.getField();
+					if (isFinal(field.getModifiers()) && isStatic(field.getModifiers())) {
+					    continue;
+					}
 					String fieldName = field.getName();
 					ApiObjectField apiObjectField = field.getAnnotation(ApiObjectField.class);
 					if (apiObjectField != null && !apiObjectField.name().isEmpty()) {

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTemplateBuilderTest.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTemplateBuilderTest.java
@@ -1,18 +1,21 @@
 package org.jsondoc.core.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import org.hamcrest.CoreMatchers;
+import org.jsondoc.core.pojo.JSONDocTemplate;
+import org.jsondoc.core.util.pojo.ClassWithConstant;
+import org.jsondoc.core.util.pojo.TemplateObject;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.jsondoc.core.pojo.JSONDocTemplate;
-import org.jsondoc.core.util.pojo.TemplateObject;
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JSONDocTemplateBuilderTest {
 
@@ -51,4 +54,20 @@ public class JSONDocTemplateBuilderTest {
 		System.out.println(mapper.writeValueAsString(template));
 	}
 
+	@Test
+	public void testTemplateWithConstant() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final Set<Class<?>> classes = Sets.<Class<?>>newHashSet(ClassWithConstant.class);
+
+        final Map<String, Object> template = JSONDocTemplateBuilder.build(ClassWithConstant.class, classes);
+        Assert.assertEquals("", template.get("identifier"));
+        Assert.assertEquals(null, template.get("TEST"));
+
+        final String serializedTemplate =
+            "{" +
+                "\"identifier\":\"\"" +
+            "}";
+
+        assertThat(mapper.writeValueAsString(template), CoreMatchers.is(serializedTemplate));
+	}
 }

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/pojo/ClassWithConstant.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/pojo/ClassWithConstant.java
@@ -1,0 +1,16 @@
+package org.jsondoc.core.util.pojo;
+
+public class ClassWithConstant {
+
+    public static final String TEST = "test";
+
+    private String identifier;
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+}


### PR DESCRIPTION
I included a check if the field is final and static, which should suffice to identify a field as a constant.