### PR TITLE
Resolves #214 @JsonRootName is ignored in playground

### DIFF
--- a/jsondoc-core/pom.xml
+++ b/jsondoc-core/pom.xml
@@ -58,6 +58,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTemplateBuilderTest.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/JSONDocTemplateBuilderTest.java
@@ -1,18 +1,19 @@
 package org.jsondoc.core.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import org.jsondoc.core.pojo.JSONDocTemplate;
+import org.jsondoc.core.util.pojo.AbstractJsonRootNameObject;
+import org.jsondoc.core.util.pojo.JsonRootNameObject;
+import org.jsondoc.core.util.pojo.TemplateObject;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import org.jsondoc.core.pojo.JSONDocTemplate;
-import org.jsondoc.core.util.pojo.TemplateObject;
-import org.junit.Assert;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
 
 public class JSONDocTemplateBuilderTest {
 
@@ -50,5 +51,19 @@ public class JSONDocTemplateBuilderTest {
 		
 		System.out.println(mapper.writeValueAsString(template));
 	}
+
+    @Test
+    public void testTemplateWithJsonRootName() throws Exception {
+        Set<Class<?>> classes = Sets.<Class<?>>newHashSet(JsonRootNameObject.class);
+        Map<String, Object> template = JSONDocTemplateBuilder.build(JsonRootNameObject.class, classes);
+        Assert.assertNotNull(template.get("data"));
+    }
+
+    @Test
+    public void testTemplateWithJsonRootNameInAbstractClass() throws Exception {
+        Set<Class<?>> classes = Sets.<Class<?>>newHashSet(AbstractJsonRootNameObject.class);
+        Map<String, Object> template = JSONDocTemplateBuilder.build(AbstractJsonRootNameObject.class, classes);
+        Assert.assertNotNull(template.get("data"));
+    }
 
 }

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/pojo/AbstractJsonRootNameObject.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/pojo/AbstractJsonRootNameObject.java
@@ -1,0 +1,18 @@
+package org.jsondoc.core.util.pojo;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+@JsonRootName("data")
+public abstract class AbstractJsonRootNameObject {
+
+    private String identifier;
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+}

--- a/jsondoc-core/src/test/java/org/jsondoc/core/util/pojo/JsonRootNameObject.java
+++ b/jsondoc-core/src/test/java/org/jsondoc/core/util/pojo/JsonRootNameObject.java
@@ -1,0 +1,4 @@
+package org.jsondoc.core.util.pojo;
+
+public class JsonRootNameObject extends AbstractJsonRootNameObject {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
 				<artifactId>jackson-databind</artifactId>
 				<version>2.0.0</version>
 			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.0.0</version>
+			</dependency>
 
 			<!-- Logging -->
 			<dependency>


### PR DESCRIPTION
To avoid Jackson annotation as a compile time dependency, JsonRootName annotation is processed dynamically.