### PR TITLE
changing the method mergeApiMethodDoc to recognize ApiHeaders

### DIFF
--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
@@ -22,6 +22,7 @@ import org.jsondoc.core.annotation.global.ApiChangelogSet;
 import org.jsondoc.core.annotation.global.ApiGlobal;
 import org.jsondoc.core.annotation.global.ApiMigrationSet;
 import org.jsondoc.core.pojo.ApiDoc;
+import org.jsondoc.core.pojo.ApiHeaderDoc;
 import org.jsondoc.core.pojo.ApiMethodDoc;
 import org.jsondoc.core.pojo.ApiObjectDoc;
 import org.jsondoc.core.pojo.JSONDocTemplate;
@@ -271,6 +272,16 @@ public abstract class AbstractSpringJSONDocScanner extends AbstractJSONDocScanne
 		if (method.isAnnotationPresent(ApiMethod.class) && method.getDeclaringClass().isAnnotationPresent(Api.class)) {
 			ApiMethodDoc jsondocApiMethodDoc = JSONDocApiMethodDocBuilder.build(method);
 			BeanUtils.copyProperties(jsondocApiMethodDoc, apiMethodDoc, new String[] { "path", "verb", "produces", "consumes", "headers", "pathparameters", "queryparameters", "bodyobject", "response", "responsestatuscode", "apierrors", "supportedversions", "auth", "displayMethodAs" });
+
+			for (ApiHeaderDoc jsondocApiHeaderDoc : jsondocApiMethodDoc.getHeaders()) {
+				
+				if(!apiMethodDoc.getHeaders().add(jsondocApiHeaderDoc)){
+					apiMethodDoc.getHeaders().remove(jsondocApiHeaderDoc);
+					apiMethodDoc.getHeaders().add(jsondocApiHeaderDoc);
+				}
+				
+			}
+			
 		}
 		return apiMethodDoc;
 	}

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/JSONDocSpringJSONDocScannerTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/JSONDocSpringJSONDocScannerTest.java
@@ -9,6 +9,8 @@ import org.jsondoc.core.annotation.ApiAuthNone;
 import org.jsondoc.core.annotation.ApiBodyObject;
 import org.jsondoc.core.annotation.ApiError;
 import org.jsondoc.core.annotation.ApiErrors;
+import org.jsondoc.core.annotation.ApiHeader;
+import org.jsondoc.core.annotation.ApiHeaders;
 import org.jsondoc.core.annotation.ApiMethod;
 import org.jsondoc.core.annotation.ApiPathParam;
 import org.jsondoc.core.annotation.ApiQueryParam;
@@ -50,6 +52,7 @@ public class JSONDocSpringJSONDocScannerTest {
 		
 		@ApiMethod(description = "Gets a string", path = "/wrongOnPurpose", verb = ApiVerb.GET)
 		@RequestMapping(value = "/string/{name}", headers = "header=test", params = "delete", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+		@ApiHeaders(headers=@ApiHeader(name="header", description="test description", allowedvalues="test"))
 		@ResponseStatus(value = HttpStatus.CREATED)
 		public @ApiResponseObject @ResponseBody String string(
 				@ApiPathParam(name = "name") @PathVariable(value = "test") String name, 
@@ -88,6 +91,7 @@ public class JSONDocSpringJSONDocScannerTest {
 				ApiHeaderDoc header = headers.iterator().next();
 				Assert.assertEquals("header", header.getName());
 				Assert.assertEquals("test", header.getAllowedvalues()[0]);
+				Assert.assertEquals("test description", header.getDescription());
 				
 				Set<ApiParamDoc> queryparameters = apiMethodDoc.getQueryparameters();
 				Assert.assertEquals(3, queryparameters.size());


### PR DESCRIPTION
This issue was created long ago and no one has commented about that. But I decided to work on it anyways. I realised that the scanner used on springmvc are only recognizing headers mapped on the RequestMapping annotation. But there you can't describe the header. What i did wont change the regular behavior but will give an option to add headers that are not mapped on the RequestMapping annotation using the ApiHeaders annotation.