### PR TITLE
ISSUE-236: fix @RequestParam(name = "param_name") ignored. name() mus…

### DIFF
--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/builder/SpringQueryParamBuilder.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/builder/SpringQueryParamBuilder.java
@@ -76,7 +76,7 @@ public class SpringQueryParamBuilder {
 				}
 				
 				if (requestParam != null) {
-					apiParamDoc = new ApiParamDoc(requestParam.value(), "", JSONDocTypeBuilder.build(new JSONDocType(), method.getParameterTypes()[i], method.getGenericParameterTypes()[i]), String.valueOf(requestParam.required()), new String[] {}, null, requestParam.defaultValue().equals(ValueConstants.DEFAULT_NONE) ? "" : requestParam.defaultValue());
+					apiParamDoc = new ApiParamDoc(requestParam.value() != null && !requestParam.value().isEmpty() ? requestParam.value() : requestParam.name() , "", JSONDocTypeBuilder.build(new JSONDocType(), method.getParameterTypes()[i], method.getGenericParameterTypes()[i]), String.valueOf(requestParam.required()), new String[] {}, null, requestParam.defaultValue().equals(ValueConstants.DEFAULT_NONE) ? "" : requestParam.defaultValue());
 					mergeApiQueryParamDoc(apiQueryParam, apiParamDoc);
 				}
 				if(modelAttribute != null) {

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/PlainSpringJSONDocScannerTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/PlainSpringJSONDocScannerTest.java
@@ -34,7 +34,7 @@ public class PlainSpringJSONDocScannerTest {
 
 		@RequestMapping(value = "/string/{name}", headers = "header=test", params = "delete", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 		@ResponseStatus(value = HttpStatus.CREATED)
-		public @ResponseBody String string(@PathVariable(value = "test") String name, @RequestParam("id") Integer id, @RequestParam Long query, @RequestHeader(value = "header-two", defaultValue = "header-test") String header, @RequestBody String requestBody) {
+		public @ResponseBody String string(@PathVariable(value = "test") String name, @RequestParam("id") Integer id, @RequestParam Long query, @RequestParam(name = "user", required = false, defaultValue = "admin") String user,				@RequestHeader(value = "header-two", defaultValue = "header-test") String header, @RequestBody String requestBody) {
 			return "ok";
 		}
 
@@ -79,7 +79,7 @@ public class PlainSpringJSONDocScannerTest {
 				Assert.assertEquals("201 - Created", apiMethodDoc.getResponsestatuscode());
 
 				Set<ApiParamDoc> queryparameters = apiMethodDoc.getQueryparameters();
-				Assert.assertEquals(3, queryparameters.size());
+				Assert.assertEquals(4, queryparameters.size());
 				Iterator<ApiParamDoc> qpIterator = queryparameters.iterator();
 				ApiParamDoc apiParamDoc = qpIterator.next();
 				Assert.assertEquals("delete", apiParamDoc.getName());
@@ -94,6 +94,11 @@ public class PlainSpringJSONDocScannerTest {
 				Assert.assertEquals("", apiParamDoc.getName());
 				Assert.assertEquals("true", apiParamDoc.getRequired());
 				Assert.assertEquals("", apiParamDoc.getDefaultvalue());
+
+				apiParamDoc = qpIterator.next();
+				Assert.assertEquals("user", apiParamDoc.getName());
+				Assert.assertEquals("false", apiParamDoc.getRequired());
+				Assert.assertEquals("admin", apiParamDoc.getDefaultvalue());
 
 				Set<ApiParamDoc> pathparameters = apiMethodDoc.getPathparameters();
 				Iterator<ApiParamDoc> ppIterator = pathparameters.iterator();

--- a/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/SpringQueryParamBuilderTest.java
+++ b/jsondoc-springmvc/src/test/java/org/jsondoc/springmvc/scanner/SpringQueryParamBuilderTest.java
@@ -76,6 +76,11 @@ public class SpringQueryParamBuilderTest {
 		public void paramThree(@RequestParam String name) {
 
 		}
+
+		@RequestMapping(value = "/param-four")
+		public void paramFour(@RequestParam(name = "value", required = false) String value) {
+
+		}
 		
 	}
 	
@@ -149,7 +154,7 @@ public class SpringQueryParamBuilderTest {
 		
 		apiDoc = jsondocScanner.getApiDocs(Sets.<Class<?>> newHashSet(SpringController3.class), MethodDisplay.URI).iterator().next();
 		Assert.assertEquals("SpringController3", apiDoc.getName());
-		Assert.assertEquals(3, apiDoc.getMethods().size());
+		Assert.assertEquals(4, apiDoc.getMethods().size());
 		for (ApiMethodDoc apiMethodDoc : apiDoc.getMethods()) {
 			if (apiMethodDoc.getPath().contains("/param-one")) {
 				Assert.assertEquals(2, apiMethodDoc.getQueryparameters().size());
@@ -178,6 +183,16 @@ public class SpringQueryParamBuilderTest {
 				ApiParamDoc queryParam = iterator.next();
 				Assert.assertEquals("", queryParam.getName());
 				Assert.assertEquals("true", queryParam.getRequired());
+				Assert.assertEquals("string", queryParam.getJsondocType().getOneLineText());
+				Assert.assertEquals("", queryParam.getDefaultvalue());
+			}
+			if (apiMethodDoc.getPath().contains("/param-four")) {
+				Assert.assertEquals(2, apiMethodDoc.getQueryparameters().size());
+				Iterator<ApiParamDoc> iterator = apiMethodDoc.getQueryparameters().iterator();
+				ApiParamDoc param = iterator.next();
+				ApiParamDoc queryParam = iterator.next();
+				Assert.assertEquals("value", queryParam.getName());
+				Assert.assertEquals("false", queryParam.getRequired());
 				Assert.assertEquals("string", queryParam.getJsondocType().getOneLineText());
 				Assert.assertEquals("", queryParam.getDefaultvalue());
 			}


### PR DESCRIPTION
…t analyze too.

Very simple fix for `@RequestParam(name = "param_name")` usage.