### PR TITLE
Update version of org.reflections:reflections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 			<dependency>
 				<groupId>org.reflections</groupId>
 				<artifactId>reflections</artifactId>
-				<version>0.9.10</version>
+				<version>0.9.11</version>
 			</dependency>
 
 			<!-- IO -->


### PR DESCRIPTION
`reflections:0.9.10` depends on guava 18, which contains a denial of
service vulnerability:

* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2018-10237

`reflections:0.9.11 ` depends on guava 20
(https://github.com/ronmamo/reflections/blob/master/pom.xml#L55) which
does not contain the mentioned vulnerability and is still Java 7
compatible (https://github.com/google/guava/wiki/Release21#java-8)