### PR TITLE
ISSUE-244 Find objects for meta annotated RequestMappings

### DIFF
--- a/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
+++ b/jsondoc-springmvc/src/main/java/org/jsondoc/springmvc/scanner/AbstractSpringJSONDocScanner.java
@@ -162,6 +162,9 @@ public abstract class AbstractSpringJSONDocScanner extends AbstractJSONDocScanne
 	@Override
 	public Set<Class<?>> jsondocObjects(List<String> packages) {
 		Set<Method> methodsAnnotatedWith = reflections.getMethodsAnnotatedWith(RequestMapping.class);
+		for(Class<?> clazz : jsondocControllers()) {
+			methodsAnnotatedWith.addAll(jsondocMethods(clazz));
+		}
 		Set<Class<?>> candidates = Sets.newHashSet();
 		Set<Class<?>> subCandidates = Sets.newHashSet();
 		Set<Class<?>> elected = Sets.newHashSet();


### PR DESCRIPTION
Re-use jsondocMethod() to find GetMapping, PostMapping, etc. meta
annotated RequestMappings.

Sorry this is not very elegant, but it works and preserves the current state, where non-controlller based methods are found as well. Let me know if this should be changed.