### PR TITLE
Fix flaky test JSONDocApiAuthBuilderTest#testApiAuthToken

### DIFF
--- a/jsondoc-core/src/main/java/org/jsondoc/core/pojo/ApiAuthDoc.java
+++ b/jsondoc-core/src/main/java/org/jsondoc/core/pojo/ApiAuthDoc.java
@@ -2,7 +2,7 @@ package org.jsondoc.core.pojo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,7 +17,7 @@ public class ApiAuthDoc {
 
 	// Token auth
 	private String scheme;
-	private Set<String> testtokens = new HashSet<String>();
+	private Set<String> testtokens = new LinkedHashSet<String>();
 
 	public String getType() {
 		return type;


### PR DESCRIPTION
The test `JSONDocApiAuthBuilderTest#testApiAuthToken` compares the result of `apiDoc.getAuth().getTesttokens()` to a hard-coded string based on a specific order of entries in `HashSet`. However, these classes do not guarantee that order, and the assertion can fail if the order differs.

The PR uses `LinkedHashSet` to make the order deterministic.