### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/deploy-snapshot.sh
+++ b/deploy-snapshot.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-mvn clean gpg:sign deploy -Dgpg.executable=gpg2 -s ~/.m2/settings.xml
+mvn -T 1C clean gpg:sign deploy -Dgpg.executable=gpg2 -s ~/.m2/settings.xml
 

--- a/jsondoc-core/pom.xml
+++ b/jsondoc-core/pom.xml
@@ -35,23 +35,11 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/jsondoc-maven-plugin/pom.xml
+++ b/jsondoc-maven-plugin/pom.xml
@@ -48,22 +48,13 @@
 			<groupId>org.jsondoc</groupId>
 			<artifactId>jsondoc-core</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.jsondoc</groupId>
-			<artifactId>jsondoc-springmvc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-		</dependency>
+		
+		
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-io</artifactId>
-		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>

--- a/jsondoc-springmvc/pom.xml
+++ b/jsondoc-springmvc/pom.xml
@@ -23,17 +23,9 @@
 			<artifactId>jsondoc-core</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<scope>provided</scope>
-		</dependency>
 		
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
+		
 
 		<dependency>
 			<groupId>org.springframework.data</groupId>

--- a/release-jsondoc.sh
+++ b/release-jsondoc.sh
@@ -18,14 +18,14 @@ DEVELOPMENTVERSION=${2}
 
 echo "Releasing with version: $RELEASEVERSION"
 
-mvn versions:set -DnewVersion=$RELEASEVERSION
+mvn -T 1C versions:set -DnewVersion=$RELEASEVERSION
 git add .
 git commit -m "poms for release version $RELEASEVERSION"
 git push origin master
 git tag -a v$RELEASEVERSION -m "tag v$RELEASEVERSION"
 git push --tags
-mvn clean gpg:sign deploy -Dgpg.executable=gpg2 -s ~/.m2/settings.xml
-mvn versions:set -DnewVersion $DEVELOPMENTVERSION
+mvn -T 1C clean gpg:sign deploy -Dgpg.executable=gpg2 -s ~/.m2/settings.xml
+mvn -T 1C versions:set -DnewVersion $DEVELOPMENTVERSION
 git add .
 git commit -m "poms for development version $DEVELOPMENTVERSION"
 git push origin master

--- a/spring-boot-starter-jsondoc/pom.xml
+++ b/spring-boot-starter-jsondoc/pom.xml
@@ -21,16 +21,9 @@
 
 	<dependencies>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+		
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
+		
 
 		<dependency>
 			<groupId>org.jsondoc</groupId>


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
jsondoc-master
jsondoc-core
{groupId='org.slf4j', artifactId='slf4j-log4j12'}
{groupId='log4j', artifactId='log4j'}
{groupId='org.springframework', artifactId='spring-webmvc'}
jsondoc-springmvc
{groupId='org.springframework', artifactId='spring-webmvc'}
{groupId='org.springframework', artifactId='spring-test'}
jsondoc-maven-plugin
{groupId='org.jsondoc', artifactId='jsondoc-springmvc'}
{groupId='org.springframework', artifactId='spring-webmvc'}
{groupId='org.apache.commons', artifactId='commons-io'}
{groupId='junit', artifactId='junit'}
jsondoc-ui
jsondoc-ui-webjar
{groupId='junit', artifactId='junit'}
spring-boot-starter-jsondoc
{groupId='org.springframework.boot', artifactId='spring-boot-starter-web'}
{groupId='org.springframework.boot', artifactId='spring-boot-configuration-processor'}
{groupId='junit', artifactId='junit'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
